### PR TITLE
Update to use Spring Boot 2.x and Camel 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.playtika.sleuth</groupId>
     <artifactId>sleuth-camel</artifactId>
     <packaging>pom</packaging>
-    <version>3.5.0-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -38,8 +38,8 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
 
         <spring-cloud-dependencies.version>Hoxton.SR8</spring-cloud-dependencies.version>
         <camel.version>3.5.0</camel.version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <groupId>com.playtika.sleuth</groupId>
     <artifactId>sleuth-camel</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.2.RELEASE</version>
+        <version>2.3.3.RELEASE</version>
     </parent>
 
     <name>sleuth-camel</name>
@@ -38,27 +38,27 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
-        <spring-cloud-dependencies.version>Greenwich.RELEASE</spring-cloud-dependencies.version>
-        <camel.version>2.23.0</camel.version>
+        <spring-cloud-dependencies.version>Hoxton.SR8</spring-cloud-dependencies.version>
+        <camel.version>3.5.0</camel.version>
 
         <!--plugins-->
-        <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
-        <maven.enforcer.plugin.version>3.0.0-M2</maven.enforcer.plugin.version>
-        <maven.javadoc.plugin.version>2.10.4</maven.javadoc.plugin.version>
-        <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
-        <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
-        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <maven.source.plugin.version>3.2.0</maven.source.plugin.version>
+        <maven.enforcer.plugin.version>3.0.0-M3</maven.enforcer.plugin.version>
+        <maven.javadoc.plugin.version>3.2.0</maven.javadoc.plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+        <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
 
         <!-- Sonar -->
-        <surefire.plugin.version>2.19.1</surefire.plugin.version>
+        <surefire.plugin.version>3.0.0-M5</surefire.plugin.version>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
         <sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
         <sonar.language>java</sonar.language>
-        <jacoco-maven-plugin.version>0.8.1</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
 
         <!-- GPG -->
         <gpg.keyname>3EEF24C7</gpg.keyname>
@@ -78,8 +78,8 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.camel</groupId>
-                <artifactId>camel-spring-boot</artifactId>
+                <groupId>org.apache.camel.springboot</groupId>
+                <artifactId>camel-spring-boot-starter</artifactId>
                 <version>${camel.version}</version>
             </dependency>
 

--- a/sleuth-camel-core/pom.xml
+++ b/sleuth-camel-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sleuth-camel</artifactId>
         <groupId>com.playtika.sleuth</groupId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -35,9 +35,15 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-spring-boot</artifactId>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-spring-boot-starter</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-direct-starter</artifactId>
+            <version>${camel.version}</version>
         </dependency>
 
         <dependency>
@@ -55,6 +61,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-mock</artifactId>
+            <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/sleuth-camel-core/pom.xml
+++ b/sleuth-camel-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sleuth-camel</artifactId>
         <groupId>com.playtika.sleuth</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -44,6 +44,7 @@
             <groupId>org.apache.camel.springboot</groupId>
             <artifactId>camel-direct-starter</artifactId>
             <version>${camel.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/sleuth-camel-core/src/main/java/com.playtika.sleuth.camel/CreatedEventNotifier.java
+++ b/sleuth-camel-core/src/main/java/com.playtika.sleuth.camel/CreatedEventNotifier.java
@@ -38,8 +38,6 @@ import org.apache.camel.spi.CamelEvent;
 import org.apache.camel.support.EventNotifierSupport;
 import org.springframework.cloud.sleuth.util.SpanNameUtil;
 
-import javax.swing.table.TableCellRenderer;
-
 import static com.playtika.sleuth.camel.SleuthCamelConstants.EXCHANGE_IS_TRACED_BY_BRAVE;
 
 @Slf4j

--- a/sleuth-camel-core/src/main/java/com.playtika.sleuth.camel/SleuthCamelAutoConfiguration.java
+++ b/sleuth-camel-core/src/main/java/com.playtika.sleuth.camel/SleuthCamelAutoConfiguration.java
@@ -53,7 +53,7 @@ public class SleuthCamelAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public CreatedEventNotifier createdEventNotifier(Tracing tracing, ThreadLocalSpan threadLocalSpan) {
-        CreatedEventNotifier createdEventNotifier = new CreatedEventNotifier(tracing, threadLocalSpan);
+        CreatedEventNotifier createdEventNotifier = new CreatedEventNotifier(tracing, threadLocalSpan, tracer);
         camelContext.getManagementStrategy().addEventNotifier(createdEventNotifier);
         return createdEventNotifier;
     }

--- a/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/SentEventNotifierTest.java
+++ b/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/SentEventNotifierTest.java
@@ -30,8 +30,9 @@ import brave.Tracer;
 import brave.propagation.ThreadLocalSpan;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
-import org.apache.camel.management.event.ExchangeCompletedEvent;
-import org.apache.camel.management.event.ExchangeSentEvent;
+import org.apache.camel.impl.event.ExchangeCompletedEvent;
+import org.apache.camel.impl.event.ExchangeSentEvent;
+import org.apache.camel.spi.CamelEvent;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,11 +40,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.EventObject;
-
 import static com.playtika.sleuth.camel.SentEventNotifier.EXCHANGE_EVENT_SENT_ANNOTATION;
 import static com.playtika.sleuth.camel.SleuthCamelConstants.EXCHANGE_IS_TRACED_BY_BRAVE;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
@@ -67,7 +65,7 @@ public class SentEventNotifierTest {
     @Test
     public void shouldProceedRemoteSpan() {
         Exchange exchange = mock(Exchange.class);
-        EventObject event = new ExchangeCompletedEvent(exchange);
+        CamelEvent event = new ExchangeCompletedEvent(exchange);
         Span currentSpan = mock(Span.class);
         Span spanToSend = mock(Span.class);
 
@@ -87,7 +85,7 @@ public class SentEventNotifierTest {
     @Test
     public void shouldProceedWithFailureMessage() {
         Exchange exchange = mock(Exchange.class);
-        EventObject event = new ExchangeCompletedEvent(exchange);
+        CamelEvent event = new ExchangeCompletedEvent(exchange);
         Span currentSpan = mock(Span.class);
         Span spanToSend = mock(Span.class);
         RuntimeException exception = new RuntimeException("some error");
@@ -112,7 +110,7 @@ public class SentEventNotifierTest {
         Endpoint exchangeEndpoint = mock(Endpoint.class);
         Exchange exchange = mock(Exchange.class);
         Span currentSpan = mock(Span.class);
-        EventObject event = new ExchangeSentEvent(exchange, eventEndpoint, 0);
+        CamelEvent event = new ExchangeSentEvent(exchange, eventEndpoint, 0);
 
         when(tracer.currentSpan()).thenReturn(currentSpan);
         when(exchange.getProperty(EXCHANGE_IS_TRACED_BY_BRAVE, Boolean.class)).thenReturn(Boolean.TRUE);
@@ -128,7 +126,7 @@ public class SentEventNotifierTest {
     @Test
     public void shouldNotProceedIfSpanNotFromCamel() {
         Exchange exchange = mock(Exchange.class);
-        EventObject event = new ExchangeCompletedEvent(exchange);
+        CamelEvent event = new ExchangeCompletedEvent(exchange);
         Span currentSpan = mock(Span.class);
 
         when(tracer.currentSpan()).thenReturn(currentSpan);
@@ -141,19 +139,11 @@ public class SentEventNotifierTest {
 
     @Test
     public void shouldNotProceedIfNotTracing() {
-        EventObject event = new ExchangeCompletedEvent(mock(Exchange.class));
+        CamelEvent event = new ExchangeCompletedEvent(mock(Exchange.class));
 
         when(tracer.currentSpan()).thenReturn(null);
 
         sentEventNotifier.notify(event);
     }
 
-    @Test
-    public void shouldBeEnabled() {
-        EventObject event = new EventObject(mock(Exchange.class));
-
-        boolean result = sentEventNotifier.isEnabled(event);
-
-        assertTrue(result);
-    }
 }

--- a/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/functional/TestApp.java
+++ b/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/functional/TestApp.java
@@ -30,6 +30,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.sleuth.annotation.NewSpan;
 import org.springframework.cloud.sleuth.util.ArrayListSpanReporter;
 import org.springframework.context.annotation.Bean;
@@ -37,8 +38,8 @@ import org.springframework.context.annotation.Configuration;
 
 import static org.apache.camel.LoggingLevel.INFO;
 
+@SpringBootApplication
 @Configuration
-@EnableAutoConfiguration
 public class TestApp {
 
     static final String DIRECT_ROUTE_URI = "direct:directRoute";


### PR DESCRIPTION
- Bumps Camel version to 3.5.0
- Bumps Spring Cloud Release to Hoxton.SR8.
- Fixes incompatibility problems and failing unit tests.