### PR TITLE
Spring Boot 2.4.4 - Spring Cloud 2020.0.2 Camel 3.9 - upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ In order to integrate functionality provided by this library tou need to add fol
 
 ```xml
 <dependency>
-   <artifactId>sleuth-camel-core</artifactId>
-   <groupId>com.playtika.sleuth</groupId>
+    <groupId>com.playtika.sleuth</groupId>
+    <artifactId>sleuth-camel-core</artifactId>
 </dependency>
 ```
 And that is pretty all, library contains spring boot auto-configuration which will do the magic with your camel context for you.
@@ -28,4 +28,7 @@ If for some reason integration should be disabled - just add following property:
 spring.sleuth.camel.enabled=false
 ```
 
-For boot 1.5.x use 1.x version, for Spring boot 2.x.x version - sleuth-camel-core 2.x version should be used.
+Version correspondence:
+* Spring Boot 1.5.x: sleuth-camel-core 1.x.
+* Spring Boot 2.0.x-2.3.x: sleuth-camel-core 2.0.x.
+* Spring Boot 2.4+: sleuth-camel-core 2.1.x.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.playtika.sleuth</groupId>
     <artifactId>sleuth-camel</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.0.0</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -43,6 +43,7 @@
 
         <spring-cloud-dependencies.version>2020.0.2</spring-cloud-dependencies.version>
         <camel.version>3.9.0</camel.version>
+        <brave-test.version>5.13.3</brave-test.version>
 
         <!--plugins-->
         <maven.source.plugin.version>3.2.0</maven.source.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <groupId>com.playtika.sleuth</groupId>
     <artifactId>sleuth-camel</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <version>2.4.4</version>
     </parent>
 
     <name>sleuth-camel</name>
@@ -41,8 +41,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <spring-cloud-dependencies.version>Hoxton.SR8</spring-cloud-dependencies.version>
-        <camel.version>3.5.0</camel.version>
+        <spring-cloud-dependencies.version>2020.0.2</spring-cloud-dependencies.version>
+        <camel.version>3.9.0</camel.version>
 
         <!--plugins-->
         <maven.source.plugin.version>3.2.0</maven.source.plugin.version>

--- a/sleuth-camel-core/pom.xml
+++ b/sleuth-camel-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sleuth-camel</artifactId>
         <groupId>com.playtika.sleuth</groupId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -82,10 +82,9 @@
         <dependency>
             <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-tests</artifactId>
-            <version>5.13.3</version>
+            <version>${brave-test.version}</version>
             <scope>test</scope>
         </dependency>
-
 
     </dependencies>
 

--- a/sleuth-camel-core/pom.xml
+++ b/sleuth-camel-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sleuth-camel</artifactId>
         <groupId>com.playtika.sleuth</groupId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,8 +14,8 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-sleuth-core</artifactId>
-            <scope>provided</scope>
+            <artifactId>spring-cloud-starter-sleuth</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -77,6 +77,15 @@
             <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/io.zipkin.brave/brave-tests -->
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-tests</artifactId>
+            <version>5.13.3</version>
+            <scope>test</scope>
+        </dependency>
+
 
     </dependencies>
 

--- a/sleuth-camel-core/src/main/java/com.playtika.sleuth.camel/CreatedEventNotifier.java
+++ b/sleuth-camel-core/src/main/java/com.playtika.sleuth.camel/CreatedEventNotifier.java
@@ -36,7 +36,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.spi.CamelEvent;
 import org.apache.camel.support.EventNotifierSupport;
-import org.springframework.cloud.sleuth.util.SpanNameUtil;
+import org.springframework.cloud.sleuth.internal.SpanNameUtil;
 
 import static com.playtika.sleuth.camel.SleuthCamelConstants.EXCHANGE_IS_TRACED_BY_BRAVE;
 

--- a/sleuth-camel-core/src/main/java/com.playtika.sleuth.camel/SentEventNotifier.java
+++ b/sleuth-camel-core/src/main/java/com.playtika.sleuth.camel/SentEventNotifier.java
@@ -24,8 +24,8 @@
 
 package com.playtika.sleuth.camel;
 
-import brave.ErrorParser;
 import brave.Span;
+import brave.Tags;
 import brave.Tracer;
 import brave.propagation.ThreadLocalSpan;
 import lombok.AllArgsConstructor;
@@ -48,7 +48,6 @@ public class SentEventNotifier extends EventNotifierSupport {
 
     private final Tracer tracer;
     private final ThreadLocalSpan threadLocalSpan;
-    private final ErrorParser errorParser;
 
     @Override
     public void notify(CamelEvent event) {
@@ -85,7 +84,7 @@ public class SentEventNotifier extends EventNotifierSupport {
 
     private boolean isCamelSpan(Exchange exchange) {
         Boolean isTracing = exchange.getProperty(EXCHANGE_IS_TRACED_BY_BRAVE, Boolean.class);
-        return isTracing == null ? false : isTracing;
+        return isTracing != null && isTracing;
     }
 
     /**
@@ -106,7 +105,7 @@ public class SentEventNotifier extends EventNotifierSupport {
         AbstractExchangeEvent abstractExchangeEvent = (AbstractExchangeEvent) event;
         Exception exception = abstractExchangeEvent.getExchange().getException();
         if (exception != null) {
-            errorParser.error(exception, span);
+            Tags.ERROR.tag(exception, span);
         }
     }
 }

--- a/sleuth-camel-core/src/main/java/com.playtika.sleuth.camel/SleuthCamelAutoConfiguration.java
+++ b/sleuth-camel-core/src/main/java/com.playtika.sleuth.camel/SleuthCamelAutoConfiguration.java
@@ -24,7 +24,6 @@
 
 package com.playtika.sleuth.camel;
 
-import brave.ErrorParser;
 import brave.Tracer;
 import brave.Tracing;
 import brave.propagation.ThreadLocalSpan;
@@ -35,7 +34,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
+import org.springframework.cloud.sleuth.autoconfig.brave.BraveAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -43,7 +42,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnBean(Tracer.class)
 @ConditionalOnClass({CamelContext.class})
-@AutoConfigureAfter(TraceAutoConfiguration.class)
+@AutoConfigureAfter({BraveAutoConfiguration.class})
 @ConditionalOnProperty(value = "spring.sleuth.camel.enabled", matchIfMissing = true)
 public class SleuthCamelAutoConfiguration {
 
@@ -60,8 +59,8 @@ public class SleuthCamelAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public SentEventNotifier sentEventNotifier(ErrorParser errorParser, ThreadLocalSpan threadLocalSpan) {
-        SentEventNotifier sentEventNotifier = new SentEventNotifier(tracer, threadLocalSpan, errorParser);
+    public SentEventNotifier sentEventNotifier(ThreadLocalSpan threadLocalSpan) {
+        SentEventNotifier sentEventNotifier = new SentEventNotifier(tracer, threadLocalSpan);
         camelContext.getManagementStrategy().addEventNotifier(sentEventNotifier);
         return sentEventNotifier;
     }

--- a/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/CreatedEventNotifierTest.java
+++ b/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/CreatedEventNotifierTest.java
@@ -84,7 +84,6 @@ public class CreatedEventNotifierTest {
         when(tracing.propagation()).thenReturn(propagation);
         when(propagation.extractor(any(Propagation.Getter.class))).thenReturn(extractor);
         when(propagation.injector(any(Propagation.Setter.class))).thenReturn(injector);
-
         notifier = new CreatedEventNotifier(tracing, threadLocalSpan, tracer);
     }
 

--- a/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/CreatedEventNotifierTest.java
+++ b/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/CreatedEventNotifierTest.java
@@ -37,20 +37,19 @@ import org.apache.camel.Message;
 import org.apache.camel.impl.event.ExchangeCreatedEvent;
 import org.apache.camel.impl.event.ExchangeSentEvent;
 import org.apache.camel.spi.CamelEvent;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.*;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 import static com.playtika.sleuth.camel.CreatedEventNotifier.EXCHANGE_EVENT_CREATED_ANNOTATION;
 import static com.playtika.sleuth.camel.CreatedEventNotifier.EXCHANGE_ID_TAG_ANNOTATION;
 import static com.playtika.sleuth.camel.SleuthCamelConstants.EXCHANGE_IS_TRACED_BY_BRAVE;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@TestInstance(PER_CLASS)
 public class CreatedEventNotifierTest {
 
     @Mock
@@ -72,8 +71,9 @@ public class CreatedEventNotifierTest {
 
     private CreatedEventNotifier notifier;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this).close();
         when(tracing.propagation()).thenReturn(propagation);
         when(propagation.extractor(any(Propagation.Getter.class))).thenReturn(extractor);
         when(propagation.injector(any(Propagation.Setter.class))).thenReturn(injector);
@@ -104,11 +104,14 @@ public class CreatedEventNotifierTest {
 
         notifier.notify(event);
 
+        verify(tracing, times(2)).propagation();
+        verify(threadLocalSpan).next(Mockito.any());
         verify(tracer).currentSpan();
         verify(span).name("camel::" + endpointKet);
         verify(span).start();
         verify(span).annotate(EXCHANGE_EVENT_CREATED_ANNOTATION);
         verify(span).tag(EXCHANGE_ID_TAG_ANNOTATION, exchange.getExchangeId());
+        verify(span).context();
         verify(exchange).setProperty(EXCHANGE_IS_TRACED_BY_BRAVE, Boolean.TRUE);
         verify(injector).inject(traceContext, message);
 
@@ -139,11 +142,14 @@ public class CreatedEventNotifierTest {
 
         notifier.notify(event);
 
+        verify(tracing, times(2)).propagation();
         verify(tracer).currentSpan();
+        verify(threadLocalSpan).next(Mockito.any());
         verify(span).name("camel::" + endpointKet);
         verify(span).start();
         verify(span).annotate(EXCHANGE_EVENT_CREATED_ANNOTATION);
         verify(span).tag(EXCHANGE_ID_TAG_ANNOTATION, exchange.getExchangeId());
+        verify(span).context();
         verify(exchange).setProperty(EXCHANGE_IS_TRACED_BY_BRAVE, Boolean.TRUE);
         verify(injector).inject(traceContext, message);
 
@@ -171,7 +177,9 @@ public class CreatedEventNotifierTest {
 
         notifier.notify(event);
 
+        verify(tracing, times(2)).propagation();
         verify(tracer).currentSpan();
+        verify(threadLocalSpan).next(Mockito.any());
         verify(span).name("camel::" + endpointKet);
         verify(span).start();
         verify(span).annotate(EXCHANGE_EVENT_CREATED_ANNOTATION);

--- a/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/CreatedEventNotifierTest.java
+++ b/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/CreatedEventNotifierTest.java
@@ -37,18 +37,26 @@ import org.apache.camel.Message;
 import org.apache.camel.impl.event.ExchangeCreatedEvent;
 import org.apache.camel.impl.event.ExchangeSentEvent;
 import org.apache.camel.spi.CamelEvent;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import static com.playtika.sleuth.camel.CreatedEventNotifier.EXCHANGE_EVENT_CREATED_ANNOTATION;
 import static com.playtika.sleuth.camel.CreatedEventNotifier.EXCHANGE_ID_TAG_ANNOTATION;
 import static com.playtika.sleuth.camel.SleuthCamelConstants.EXCHANGE_IS_TRACED_BY_BRAVE;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 @TestInstance(PER_CLASS)
 public class CreatedEventNotifierTest {
 
@@ -73,7 +81,6 @@ public class CreatedEventNotifierTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        MockitoAnnotations.openMocks(this).close();
         when(tracing.propagation()).thenReturn(propagation);
         when(propagation.extractor(any(Propagation.Getter.class))).thenReturn(extractor);
         when(propagation.injector(any(Propagation.Setter.class))).thenReturn(injector);

--- a/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/SentEventNotifierTest.java
+++ b/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/SentEventNotifierTest.java
@@ -58,14 +58,10 @@ public class SentEventNotifierTest {
     @InjectMocks
     private SentEventNotifier sentEventNotifier;
 
-    @BeforeEach
-    public void setUp() {
-        sentEventNotifier = new SentEventNotifier(tracer, threadLocalSpan);
-    }
-
     @AfterEach
     public void tearDown() {
         verifyNoMoreInteractions(tracer);
+        sentEventNotifier = null;
     }
 
     @Test

--- a/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/SentEventNotifierTest.java
+++ b/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/SentEventNotifierTest.java
@@ -24,7 +24,6 @@
 
 package com.playtika.sleuth.camel;
 
-import brave.ErrorParser;
 import brave.Span;
 import brave.Tracer;
 import brave.propagation.ThreadLocalSpan;
@@ -33,33 +32,35 @@ import org.apache.camel.Exchange;
 import org.apache.camel.impl.event.ExchangeCompletedEvent;
 import org.apache.camel.impl.event.ExchangeSentEvent;
 import org.apache.camel.spi.CamelEvent;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.*;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 import static com.playtika.sleuth.camel.SentEventNotifier.EXCHANGE_EVENT_SENT_ANNOTATION;
 import static com.playtika.sleuth.camel.SleuthCamelConstants.EXCHANGE_IS_TRACED_BY_BRAVE;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@TestInstance(PER_CLASS)
 public class SentEventNotifierTest {
 
     @Mock
     private Tracer tracer;
     @Mock
-    private ErrorParser errorParser;
-    @Mock
     private ThreadLocalSpan threadLocalSpan;
 
-    @InjectMocks
     private SentEventNotifier sentEventNotifier;
 
-    @After
+    @BeforeEach
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this).close();
+        sentEventNotifier = new SentEventNotifier(tracer, threadLocalSpan);
+    }
+
+    @AfterEach
     public void tearDown() {
-        verifyNoMoreInteractions(tracer, errorParser);
+        verifyNoMoreInteractions(tracer);
     }
 
     @Test
@@ -76,6 +77,7 @@ public class SentEventNotifierTest {
 
         sentEventNotifier.notify(event);
 
+        verify(tracer).currentSpan();
         verify(exchange).removeProperty(EXCHANGE_IS_TRACED_BY_BRAVE);
         verify(spanToSend).annotate(EXCHANGE_EVENT_SENT_ANNOTATION);
         verify(spanToSend).finish();
@@ -97,10 +99,15 @@ public class SentEventNotifierTest {
 
         sentEventNotifier.notify(event);
 
+        verify(tracer).currentSpan();
         verify(exchange).removeProperty(EXCHANGE_IS_TRACED_BY_BRAVE);
-        verify(errorParser).error(exception, spanToSend);
         verify(spanToSend).annotate(EXCHANGE_EVENT_SENT_ANNOTATION);
         verify(spanToSend).finish();
+        verify(spanToSend).tag(Mockito.any(), Mockito.any());
+        verify(spanToSend).annotate(Mockito.any());
+        verify(spanToSend).finish();
+        verify(spanToSend).isNoop();
+        verify(spanToSend).context();
         verifyNoMoreInteractions(currentSpan, spanToSend);
     }
 
@@ -120,6 +127,7 @@ public class SentEventNotifierTest {
 
         sentEventNotifier.notify(event);
 
+        verify(tracer).currentSpan();
         verifyNoMoreInteractions(currentSpan);
     }
 
@@ -134,6 +142,7 @@ public class SentEventNotifierTest {
 
         sentEventNotifier.notify(event);
 
+        verify(tracer).currentSpan();
         verifyNoMoreInteractions(currentSpan);
     }
 
@@ -144,6 +153,8 @@ public class SentEventNotifierTest {
         when(tracer.currentSpan()).thenReturn(null);
 
         sentEventNotifier.notify(event);
+
+        verify(tracer).currentSpan();
     }
 
 }

--- a/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/SentEventNotifierTest.java
+++ b/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/SentEventNotifierTest.java
@@ -32,23 +32,25 @@ import org.apache.camel.Exchange;
 import org.apache.camel.impl.event.ExchangeCompletedEvent;
 import org.apache.camel.impl.event.ExchangeSentEvent;
 import org.apache.camel.spi.CamelEvent;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import static com.playtika.sleuth.camel.SentEventNotifier.EXCHANGE_EVENT_SENT_ANNOTATION;
 import static com.playtika.sleuth.camel.SleuthCamelConstants.EXCHANGE_IS_TRACED_BY_BRAVE;
-import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 import static org.mockito.Mockito.*;
+import static org.mockito.quality.Strictness.STRICT_STUBS;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.STRICT_STUBS)
-@TestInstance(PER_CLASS)
+@MockitoSettings(strictness = STRICT_STUBS)
+@TestInstance(PER_METHOD)
 public class SentEventNotifierTest {
 
     @Mock()
@@ -61,7 +63,6 @@ public class SentEventNotifierTest {
     @AfterEach
     public void tearDown() {
         verifyNoMoreInteractions(tracer);
-        sentEventNotifier = null;
     }
 
     @Test

--- a/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/SentEventNotifierTest.java
+++ b/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/SentEventNotifierTest.java
@@ -33,28 +33,33 @@ import org.apache.camel.impl.event.ExchangeCompletedEvent;
 import org.apache.camel.impl.event.ExchangeSentEvent;
 import org.apache.camel.spi.CamelEvent;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import static com.playtika.sleuth.camel.SentEventNotifier.EXCHANGE_EVENT_SENT_ANNOTATION;
 import static com.playtika.sleuth.camel.SleuthCamelConstants.EXCHANGE_IS_TRACED_BY_BRAVE;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 @TestInstance(PER_CLASS)
 public class SentEventNotifierTest {
 
-    @Mock
+    @Mock()
     private Tracer tracer;
     @Mock
     private ThreadLocalSpan threadLocalSpan;
-
+    @InjectMocks
     private SentEventNotifier sentEventNotifier;
 
     @BeforeEach
-    public void setUp() throws Exception {
-        MockitoAnnotations.openMocks(this).close();
+    public void setUp() {
         sentEventNotifier = new SentEventNotifier(tracer, threadLocalSpan);
     }
 

--- a/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/functional/TestApp.java
+++ b/sleuth-camel-core/src/test/java/com/playtika/sleuth/camel/functional/TestApp.java
@@ -25,14 +25,13 @@
 package com.playtika.sleuth.camel.functional;
 
 import brave.sampler.Sampler;
+import brave.test.TestSpanHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Processor;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.sleuth.annotation.NewSpan;
-import org.springframework.cloud.sleuth.util.ArrayListSpanReporter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -46,8 +45,8 @@ public class TestApp {
     static final String ASYNC_DIRECT_ROUTE_URI = "direct:asyncDirectRoute";
     static final String MOCK_DIRECT_ROUTE_TO_URI = "mock:directRouteTo";
     static final String MOCK_EXCEPTION_ROUTE_TO_URI = "mock:exceptionRouteTo";
-    static final String DIRECT_ROUTE_ID = "directroute";
-    static final String ASYNC_DIRECT_ROUTE_ID = "asyncdirectroute";
+    static final String DIRECT_ROUTE_ID = "directRoute";
+    static final String ASYNC_DIRECT_ROUTE_ID = "asyncDirectRoute";
 
     @Bean
     public Sampler alwaysSampler() {
@@ -55,8 +54,8 @@ public class TestApp {
     }
 
     @Bean
-    public ArrayListSpanReporter arrayListSpanAccumulator() {
-        return new ArrayListSpanReporter();
+    public TestSpanHandler testSpanHandler() {
+        return new TestSpanHandler();
     }
 
     @Bean


### PR DESCRIPTION
This PR upgrades the project to be compatible with Spring Boot 2.4.4, Spring Cloud 2020.0.2 (Sleuth 3.x) and Camel 3.9